### PR TITLE
feat(storage): add SQLite ORM and repository

### DIFF
--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -1,0 +1,50 @@
+"""Database setup for SQLAlchemy sessions and engine."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+# Default SQLite database URL; individual components/tests may override
+DEFAULT_DB_URL = "sqlite:///./data/app.db"
+
+# Engine and session factory are created lazily so tests can supply custom URLs.
+_engine = None
+_SessionLocal = None
+
+
+def init_engine(db_url: str = DEFAULT_DB_URL) -> None:
+    """Initialise the global SQLAlchemy engine and session factory."""
+    global _engine, _SessionLocal
+    if _engine is None:
+        _engine = create_engine(db_url, future=True, connect_args={"check_same_thread": False})
+        _SessionLocal = sessionmaker(bind=_engine, expire_on_commit=False, class_=Session)
+
+
+def get_engine() -> "Engine":  # type: ignore[name-defined]
+    if _engine is None:
+        init_engine()
+    return _engine
+
+
+def get_session() -> Session:
+    if _SessionLocal is None:
+        init_engine()
+    return _SessionLocal()
+
+
+@contextmanager
+def session_scope() -> Generator[Session, None, None]:
+    """Provide a transactional scope around a series of operations."""
+    session = get_session()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -20,8 +20,12 @@ def init_engine(db_url: str = DEFAULT_DB_URL) -> None:
     """Initialise the global SQLAlchemy engine and session factory."""
     global _engine, _SessionLocal
     if _engine is None:
-        _engine = create_engine(db_url, future=True, connect_args={"check_same_thread": False})
-        _SessionLocal = sessionmaker(bind=_engine, expire_on_commit=False, class_=Session)
+        _engine = create_engine(
+            db_url, future=True, connect_args={"check_same_thread": False}
+        )
+        _SessionLocal = sessionmaker(
+            bind=_engine, expire_on_commit=False, class_=Session
+        )
 
 
 def get_engine() -> "Engine":  # type: ignore[name-defined]

--- a/app/storage/models.py
+++ b/app/storage/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Optional
 
 from sqlalchemy import DateTime, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -22,7 +22,7 @@ class Frame(Base):
     path: Mapped[str] = mapped_column(String, nullable=False)
     checksum: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
-    events: Mapped[List["Event"]] = relationship(back_populates="frame")
+    events: Mapped[list["Event"]] = relationship(back_populates="frame")
 
 
 class Event(Base):
@@ -33,21 +33,23 @@ class Event(Base):
     severity: Mapped[str] = mapped_column(String, nullable=False)
     frame_id: Mapped[int] = mapped_column(ForeignKey("frames.id"), nullable=False)
     confidence: Mapped[float] = mapped_column(Float, nullable=False)
-    metrics: Mapped[Dict[str, float]] = mapped_column(JSON, default=dict)
+    metrics: Mapped[dict[str, float]] = mapped_column(JSON, default=dict)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     frame: Mapped[Frame] = relationship(back_populates="events")
-    drafts: Mapped[List["Draft"]] = relationship(back_populates="event")
+    drafts: Mapped[list["Draft"]] = relationship(back_populates="event")
 
 
 class Draft(Base):
     __tablename__ = "drafts"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), nullable=False, unique=True)
+    event_id: Mapped[int] = mapped_column(
+        ForeignKey("events.id"), nullable=False, unique=True
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     body_md: Mapped[str] = mapped_column(String, nullable=False)
-    attachments: Mapped[List[str]] = mapped_column(JSON, default=list)
+    attachments: Mapped[list[str]] = mapped_column(JSON, default=list)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     event: Mapped[Event] = relationship(back_populates="drafts")

--- a/app/storage/models.py
+++ b/app/storage/models.py
@@ -1,0 +1,56 @@
+"""SQLAlchemy ORM models for persisting frames, events and drafts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.types import JSON
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Frame(Base):
+    __tablename__ = "frames"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    timestamp: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    path: Mapped[str] = mapped_column(String, nullable=False)
+    checksum: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
+    events: Mapped[List["Event"]] = relationship(back_populates="frame")
+
+
+class Event(Base):
+    __tablename__ = "events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    type: Mapped[str] = mapped_column(String, nullable=False)
+    severity: Mapped[str] = mapped_column(String, nullable=False)
+    frame_id: Mapped[int] = mapped_column(ForeignKey("frames.id"), nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    metrics: Mapped[Dict[str, float]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    frame: Mapped[Frame] = relationship(back_populates="events")
+    drafts: Mapped[List["Draft"]] = relationship(back_populates="event")
+
+
+class Draft(Base):
+    __tablename__ = "drafts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), nullable=False, unique=True)
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    body_md: Mapped[str] = mapped_column(String, nullable=False)
+    attachments: Mapped[List[str]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    event: Mapped[Event] = relationship(back_populates="drafts")
+
+
+__all__ = ["Base", "Frame", "Event", "Draft"]

--- a/app/storage/repo.py
+++ b/app/storage/repo.py
@@ -1,0 +1,86 @@
+"""Repository helpers for persisting and querying domain models."""
+
+from __future__ import annotations
+
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from app.schemas.models import AnomalyEvent, BugDraft, FramePacket
+
+from . import models
+
+
+def save_frame(session: Session, packet: FramePacket) -> models.Frame:
+    """Persist a :class:`FramePacket` to the database."""
+    frame = session.get(models.Frame, packet.frame_id)
+    if frame is None:
+        frame = models.Frame(
+            id=packet.frame_id,
+            timestamp=packet.timestamp,
+            path=str(packet.path),
+            checksum=packet.checksum,
+        )
+        session.add(frame)
+    else:
+        frame.timestamp = packet.timestamp
+        frame.path = str(packet.path)
+        frame.checksum = packet.checksum
+    session.commit()
+    return frame
+
+
+def save_event(session: Session, event: AnomalyEvent) -> models.Event:
+    """Persist an :class:`AnomalyEvent` and its frame."""
+    frame = save_frame(session, event.frame)
+    db_event = session.get(models.Event, event.event_id)
+    if db_event is None:
+        db_event = models.Event(
+            id=event.event_id,
+            type=event.type.value,
+            severity=event.severity.value,
+            frame_id=frame.id,
+            confidence=event.confidence,
+            metrics=event.metrics,
+            created_at=event.created_at,
+        )
+        session.add(db_event)
+    else:
+        db_event.type = event.type.value
+        db_event.severity = event.severity.value
+        db_event.frame_id = frame.id
+        db_event.confidence = event.confidence
+        db_event.metrics = event.metrics
+        db_event.created_at = event.created_at
+    session.commit()
+    return db_event
+
+
+def save_draft(session: Session, draft: BugDraft) -> models.Draft:
+    """Persist a :class:`BugDraft` and ensure its event exists."""
+    event = save_event(session, draft.event)
+    db_draft = session.query(models.Draft).filter_by(event_id=event.id).one_or_none()
+    if db_draft is None:
+        db_draft = models.Draft(
+            event_id=event.id,
+            title=draft.title,
+            body_md=draft.body_md,
+            attachments=draft.attachments,
+            created_at=draft.created_at,
+        )
+        session.add(db_draft)
+    else:
+        db_draft.title = draft.title
+        db_draft.body_md = draft.body_md
+        db_draft.attachments = draft.attachments
+        db_draft.created_at = draft.created_at
+    session.commit()
+    return db_draft
+
+
+def list_events(session: Session) -> List[models.Event]:
+    """Return all stored events."""
+    return session.query(models.Event).all()
+
+
+__all__ = ["save_frame", "save_event", "save_draft", "list_events"]

--- a/app/storage/repo.py
+++ b/app/storage/repo.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import List
-
 from sqlalchemy.orm import Session
 
 from app.schemas.models import AnomalyEvent, BugDraft, FramePacket
@@ -26,7 +24,6 @@ def save_frame(session: Session, packet: FramePacket) -> models.Frame:
         frame.timestamp = packet.timestamp
         frame.path = str(packet.path)
         frame.checksum = packet.checksum
-    session.commit()
     return frame
 
 
@@ -52,7 +49,6 @@ def save_event(session: Session, event: AnomalyEvent) -> models.Event:
         db_event.confidence = event.confidence
         db_event.metrics = event.metrics
         db_event.created_at = event.created_at
-    session.commit()
     return db_event
 
 
@@ -74,13 +70,12 @@ def save_draft(session: Session, draft: BugDraft) -> models.Draft:
         db_draft.body_md = draft.body_md
         db_draft.attachments = draft.attachments
         db_draft.created_at = draft.created_at
-    session.commit()
     return db_draft
 
 
-def list_events(session: Session) -> List[models.Event]:
-    """Return all stored events."""
-    return session.query(models.Event).all()
+def list_events(session: Session) -> list[models.Event]:
+    """Return all stored events ordered by creation time."""
+    return session.query(models.Event).order_by(models.Event.created_at).all()
 
 
 __all__ = ["save_frame", "save_event", "save_draft", "list_events"]

--- a/tests/unit/test_storage_repo.py
+++ b/tests/unit/test_storage_repo.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.schemas.models import AnomalyEvent, BugDraft, FramePacket
+from app.schemas.types import AnomalyType, Severity
+from app.storage import models, repo
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    models.Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def sample_event() -> AnomalyEvent:
+    frame = FramePacket(frame_id=1, timestamp=datetime.utcnow(), path=Path("/tmp/frame.png"))
+    return AnomalyEvent(
+        event_id=1,
+        type=AnomalyType.BLANK,
+        severity=Severity.LOW,
+        frame=frame,
+        confidence=0.9,
+        metrics={"value": 1.0},
+        created_at=datetime.utcnow(),
+    )
+
+
+def test_save_event_and_list_events():
+    event = sample_event()
+    with make_session() as session:
+        repo.save_event(session, event)
+        events = repo.list_events(session)
+        assert len(events) == 1
+        stored = events[0]
+        assert stored.id == event.event_id
+        assert stored.frame.path == str(event.frame.path)
+
+
+def test_save_draft():
+    event = sample_event()
+    draft = BugDraft(event=event, title="Title", body_md="Body", attachments=["a.png"])
+    with make_session() as session:
+        repo.save_draft(session, draft)
+        stored = session.query(models.Draft).one()
+        assert stored.title == draft.title
+        assert stored.event.id == event.event_id

--- a/tests/unit/test_storage_repo.py
+++ b/tests/unit/test_storage_repo.py
@@ -18,7 +18,9 @@ def make_session():
 
 
 def sample_event() -> AnomalyEvent:
-    frame = FramePacket(frame_id=1, timestamp=datetime.utcnow(), path=Path("/tmp/frame.png"))
+    frame = FramePacket(
+        frame_id=1, timestamp=datetime.utcnow(), path=Path("/tmp/frame.png")
+    )
     return AnomalyEvent(
         event_id=1,
         type=AnomalyType.BLANK,


### PR DESCRIPTION
## Summary
- add database module with configurable SQLite engine and session helpers
- define ORM tables for frames, events, and drafts
- implement repository CRUD utilities and unit tests for persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1da30b0888328b161018d4bb4f378