### PR TITLE
feat(pipeline): connect capture to detectors and persist artifacts

### DIFF
--- a/app/config/detectors.yaml
+++ b/app/config/detectors.yaml
@@ -1,0 +1,4 @@
+detectors:
+  - blank
+  - freeze
+  - flicker

--- a/app/detectors/pipeline.py
+++ b/app/detectors/pipeline.py
@@ -1,0 +1,69 @@
+"""Detection pipeline loading detectors from configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Sequence, Set, Tuple, Type
+
+import yaml
+
+from app.schemas.models import AnomalyEvent, FramePacket
+
+from .base import Detector, DetectorState
+from .blank import BlankDetector
+from .flicker import FlickerDetector
+from .freeze import FreezeDetector
+
+DetectorFactory = Type[Detector]
+
+NAME_MAP: Dict[str, DetectorFactory] = {
+    "blank": BlankDetector,
+    "freeze": FreezeDetector,
+    "flicker": FlickerDetector,
+}
+
+
+class DetectorPipeline:
+    """Manage a sequence of detectors and deduplicate emitted events."""
+
+    def __init__(self, detectors: Sequence[Detector]) -> None:
+        self.detectors = list(detectors)
+        self._states: List[DetectorState] = [{} for _ in self.detectors]
+        # track (anomaly_type, frame_id) to avoid duplicate events
+        self._seen: Set[Tuple[str, int]] = set()
+
+    @classmethod
+    def from_yaml(cls, path: Path | None = None) -> "DetectorPipeline":
+        """Instantiate detectors based on a YAML configuration."""
+        if path is None:
+            path = Path(__file__).resolve().parent.parent / "config" / "detectors.yaml"
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as fh:
+                cfg = yaml.safe_load(fh) or {}
+            order = cfg.get("detectors", [])
+        else:  # fallback to all known detectors
+            order = list(NAME_MAP.keys())
+
+        detectors: List[Detector] = []
+        for name in order:
+            factory = NAME_MAP.get(name)
+            if factory is not None:
+                detectors.append(factory())
+        return cls(detectors)
+
+    def process(self, pkt: FramePacket) -> List[AnomalyEvent]:
+        """Run all detectors over a frame packet and return new events."""
+        events: List[AnomalyEvent] = []
+        for det, state in zip(self.detectors, self._states):
+            evt = det.process(pkt, state)
+            if evt is None:
+                continue
+            key = (evt.type.value, evt.frame.frame_id)
+            if key in self._seen:
+                continue
+            self._seen.add(key)
+            events.append(evt)
+        return events
+
+
+__all__ = ["DetectorPipeline"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,25 +1,61 @@
+"""Entry point wiring capture, detection and storage via asyncio queues."""
+
+from __future__ import annotations
+
 import asyncio
+from asyncio import Queue
+
+from app.detectors.pipeline import DetectorPipeline
+from app.schemas.models import AnomalyEvent, FramePacket
+from app.storage import artifacts, repo
+from app.storage.db import session_scope
 
 
-async def capture_loop():
-    """Placeholder for frame capture logic."""
-    await asyncio.sleep(0)
+async def capture_loop(frame_q: Queue[FramePacket]) -> None:
+    """Placeholder for frame capture logic.
+
+    This mock loop currently does nothing but is structured to put
+    :class:`FramePacket` objects onto ``frame_q`` in a real implementation.
+    """
+
+    while True:  # pragma: no cover - loop body is placeholder
+        await asyncio.sleep(1)
 
 
-async def detect_loop():
-    """Placeholder for anomaly detection logic."""
-    await asyncio.sleep(0)
+async def detect_loop(
+    frame_q: Queue[FramePacket], event_q: Queue[AnomalyEvent]
+) -> None:
+    """Consume frames, run detectors and emit events."""
+
+    pipeline = DetectorPipeline.from_yaml()
+    while True:
+        pkt = await frame_q.get()
+        events = pipeline.process(pkt)
+        for evt in events:
+            await event_q.put(evt)
 
 
-async def nlp_loop():
-    """Placeholder for NLP summarization logic."""
-    await asyncio.sleep(0)
+async def event_loop(event_q: Queue[AnomalyEvent]) -> None:
+    """Persist events and associated artifacts."""
+
+    with session_scope() as session:
+        while True:
+            evt = await event_q.get()
+            repo.save_event(session, evt)
+            artifacts.save_event_artifacts(evt)
 
 
 async def main() -> None:
-    """Run core loops concurrently."""
-    await asyncio.gather(capture_loop(), detect_loop(), nlp_loop())
+    """Run capture, detection and storage concurrently."""
+
+    frame_q: Queue[FramePacket] = asyncio.Queue()
+    event_q: Queue[AnomalyEvent] = asyncio.Queue()
+    await asyncio.gather(
+        capture_loop(frame_q),
+        detect_loop(frame_q, event_q),
+        event_loop(event_q),
+    )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry
     asyncio.run(main())

--- a/app/storage/artifacts.py
+++ b/app/storage/artifacts.py
@@ -1,0 +1,93 @@
+"""Utilities for persisting event artifacts to disk."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence
+
+from shutil import copyfile
+
+try:  # pragma: no cover - optional dependency
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - executed when OpenCV unavailable
+    cv2 = None
+
+from app.schemas.models import AnomalyEvent
+
+
+def save_event_artifacts(
+    event: AnomalyEvent,
+    pre: Sequence[Path] | None = None,
+    post: Sequence[Path] | None = None,
+    events_dir: Path | None = None,
+    artifacts_dir: Path | None = None,
+    fps: int = 5,
+) -> Path:
+    """Persist screenshot, metrics and a short clip for an event.
+
+    Args:
+        event: The anomaly event being stored.
+        pre: Paths to frames before the event.
+        post: Paths to frames after the event.
+        events_dir: Root directory for per-event folders.
+        artifacts_dir: Directory for global artifact files.
+        fps: Frame rate for the stitched clip.
+
+    Returns:
+        The directory where event artifacts were saved.
+    """
+
+    pre_paths = list(pre or [])
+    post_paths = list(post or [])
+    events_root = events_dir or Path("events")
+    artifacts_root = artifacts_dir or Path("artifacts")
+    events_root.mkdir(parents=True, exist_ok=True)
+    artifacts_root.mkdir(parents=True, exist_ok=True)
+
+    event_dir = events_root / str(event.event_id)
+    event_dir.mkdir(parents=True, exist_ok=True)
+
+    # screenshot
+    screenshot = event_dir / "screenshot.png"
+    if cv2 is not None:
+        img = cv2.imread(str(event.frame.path))
+        if img is not None:
+            cv2.imwrite(str(screenshot), img)
+    else:  # pragma: no cover - executed if OpenCV missing
+        copyfile(event.frame.path, screenshot)
+
+    # metrics
+    metrics_path = artifacts_root / "metrics.json"
+    metrics: dict[str, object] = {}
+    if metrics_path.exists():
+        try:
+            metrics = json.loads(metrics_path.read_text())
+        except Exception:  # pragma: no cover - corrupted file
+            metrics = {}
+    metrics[str(event.event_id)] = event.metrics
+    metrics_path.write_text(json.dumps(metrics))
+
+    # clip
+    clip_frames = pre_paths + [event.frame.path] + post_paths
+    if cv2 is not None and clip_frames:
+        first = cv2.imread(str(clip_frames[0]))
+        if first is not None:
+            height, width, _ = first.shape
+            clip_path = event_dir / "clip.mp4"
+            writer = cv2.VideoWriter(
+                str(clip_path),
+                cv2.VideoWriter_fourcc(*"mp4v"),
+                fps,
+                (width, height),
+            )
+            for path in clip_frames:
+                frame = cv2.imread(str(path))
+                if frame is not None:
+                    writer.write(frame)
+            writer.release()
+
+    return event_dir
+
+
+__all__ = ["save_event_artifacts"]

--- a/tests/integration/test_pipeline_artifacts.py
+++ b/tests/integration/test_pipeline_artifacts.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import json
+from datetime import datetime
+from pathlib import Path
+
+import cv2
+import numpy as np
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.detectors.pipeline import DetectorPipeline
+from app.schemas.models import FramePacket
+from app.storage import artifacts, models, repo
+
+
+def make_packet(img: np.ndarray, tmp_path: Path, frame_id: int) -> FramePacket:
+    path = tmp_path / f"frame_{frame_id}.png"
+    cv2.imwrite(str(path), img)
+    return FramePacket(frame_id=frame_id, timestamp=datetime.utcnow(), path=path)
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    models.Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_pipeline_generates_artifacts(tmp_path):
+    black = np.zeros((32, 32, 3), dtype=np.uint8)
+    pipeline = DetectorPipeline.from_yaml()
+    events_dir = tmp_path / "events"
+    artifacts_dir = tmp_path / "artifacts"
+
+    session = make_session()
+    try:
+        for i in range(5):
+            pkt = make_packet(black, tmp_path, i)
+            for evt in pipeline.process(pkt):
+                repo.save_event(session, evt)
+                artifacts.save_event_artifacts(
+                    evt, events_dir=events_dir, artifacts_dir=artifacts_dir
+                )
+        session.commit()
+
+        stored = session.query(models.Event).all()
+        assert len(stored) == 1
+        event_id = stored[0].id
+    finally:
+        session.close()
+
+    screenshot = events_dir / str(event_id) / "screenshot.png"
+    assert screenshot.exists()
+
+    metrics_path = artifacts_dir / "metrics.json"
+    data = json.loads(metrics_path.read_text())
+    assert str(event_id) in data


### PR DESCRIPTION
## Summary
- connect capture, detection, and storage via async queues
- create detector pipeline loading order from YAML and deduplicating events
- persist event artifacts including screenshot, metrics, and video clips

## Testing
- `poetry run black .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1ef983b148328b3441a5dd97b1858