### PR TITLE
feat(nlp): add rule-based bug draft generator

### DIFF
--- a/app/nlp/summarizer.py
+++ b/app/nlp/summarizer.py
@@ -1,6 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
 from app.schemas.models import AnomalyEvent, BugDraft
+from .templates import DEFAULT_TEMPLATE, TEMPLATES
+
+# Load simple context from config/settings.yaml
+_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "settings.yaml"
+
+
+def _load_settings(path: Path) -> Dict[str, object]:
+    if path.exists():
+        with open(path, "r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    return {}
+
+
+_SETTINGS = _load_settings(_CONFIG_PATH)
+
+
+def _environment_context() -> str:
+    """Compose a small environment string from config settings."""
+    fps = _SETTINGS.get("fps")
+    buffer_s = _SETTINGS.get("buffer_seconds")
+    parts = []
+    if fps is not None:
+        parts.append(f"fps={fps}")
+    if buffer_s is not None:
+        parts.append(f"buffer={buffer_s}s")
+    return ", ".join(parts)
+
+
+def _metrics_to_md(metrics: Dict[str, object]) -> str:
+    if not metrics:
+        return "none"
+    return "\n".join(f"- {k}: {v}" for k, v in metrics.items())
 
 
 def summarize(event: AnomalyEvent) -> BugDraft:
-    """Summarize an anomaly event into a bug draft."""
-    return BugDraft(summary="", description="", event=event)
+    """Summarize an anomaly event into a :class:`BugDraft`."""
+
+    template = TEMPLATES.get(event.type, DEFAULT_TEMPLATE)
+    env = _environment_context()
+    metrics_md = _metrics_to_md(event.metrics)
+    event_type = event.type.value.replace("_", " ").title()
+
+    title = template.title.format(event_type=event_type)
+    body_md = template.body.format(
+        severity=event.severity.value,
+        environment=env,
+        metrics_md=metrics_md,
+        event_type=event_type,
+    )
+    return BugDraft(event=event, title=title, body_md=body_md)

--- a/app/nlp/templates.py
+++ b/app/nlp/templates.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from app.schemas.types import AnomalyType
+
+
+@dataclass
+class Template:
+    """Simple container for title and body templates."""
+
+    title: str
+    body: str
+
+
+TEMPLATES: Dict[AnomalyType, Template] = {
+    AnomalyType.BLANK: Template(
+        title="Blank Screen Detected",
+        body=(
+            "# Blank Screen Detected\n"
+            "**Severity**: {severity}\n"
+            "**Environment**: {environment}\n\n"
+            "## Observed\n"
+            "Game rendered a blank screen.\n\n"
+            "## Expected\n"
+            "Normal gameplay visuals.\n\n"
+            "## Metrics\n"
+            "{metrics_md}\n"
+        ),
+    ),
+    AnomalyType.FREEZE: Template(
+        title="Freeze Detected",
+        body=(
+            "# Freeze Detected\n"
+            "**Severity**: {severity}\n"
+            "**Environment**: {environment}\n\n"
+            "## Observed\n"
+            "Gameplay appeared frozen.\n\n"
+            "## Expected\n"
+            "Smooth continuous motion.\n\n"
+            "## Metrics\n"
+            "{metrics_md}\n"
+        ),
+    ),
+    AnomalyType.FLICKER: Template(
+        title="Flicker Detected",
+        body=(
+            "# Flicker Detected\n"
+            "**Severity**: {severity}\n"
+            "**Environment**: {environment}\n\n"
+            "## Observed\n"
+            "Rapid brightness changes observed.\n\n"
+            "## Expected\n"
+            "Stable lighting and colours.\n\n"
+            "## Metrics\n"
+            "{metrics_md}\n"
+        ),
+    ),
+    AnomalyType.HUD_GLITCH: Template(
+        title="HUD Glitch Detected",
+        body=(
+            "# HUD Glitch Detected\n"
+            "**Severity**: {severity}\n"
+            "**Environment**: {environment}\n\n"
+            "## Observed\n"
+            "HUD elements appeared corrupted.\n\n"
+            "## Expected\n"
+            "Correct and stable HUD rendering.\n\n"
+            "## Metrics\n"
+            "{metrics_md}\n"
+        ),
+    ),
+}
+
+DEFAULT_TEMPLATE = Template(
+    title="{event_type} Anomaly Detected",
+    body=(
+        "# {event_type} Anomaly Detected\n"
+        "**Severity**: {severity}\n"
+        "**Environment**: {environment}\n\n"
+        "## Metrics\n"
+        "{metrics_md}\n"
+    ),
+)
+
+__all__ = ["Template", "TEMPLATES", "DEFAULT_TEMPLATE"]

--- a/tests/unit/test_summarizer.py
+++ b/tests/unit/test_summarizer.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import app.nlp.summarizer as summarizer
+from app.schemas.models import AnomalyEvent, FramePacket
+from app.schemas.types import AnomalyType, Severity
+from app.storage import models, repo
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    models.Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def sample_event(
+    anomaly_type: Enum = AnomalyType.BLANK,
+    metrics: dict | None = None,
+    severity: Severity = Severity.LOW,
+) -> AnomalyEvent:
+    frame = FramePacket(
+        frame_id=1, timestamp=datetime.utcnow(), path=Path("/tmp/frame.png")
+    )
+    return AnomalyEvent(
+        event_id=1,
+        type=anomaly_type,
+        severity=severity,
+        frame=frame,
+        confidence=0.9,
+        metrics={"value": 1.0} if metrics is None else metrics,
+        created_at=datetime.utcnow(),
+    )
+
+
+@pytest.mark.parametrize(
+    "atype,title,observed",
+    [
+        (
+            AnomalyType.BLANK,
+            "Blank Screen Detected",
+            "Game rendered a blank screen.",
+        ),
+        (
+            AnomalyType.FREEZE,
+            "Freeze Detected",
+            "Gameplay appeared frozen.",
+        ),
+        (
+            AnomalyType.FLICKER,
+            "Flicker Detected",
+            "Rapid brightness changes observed.",
+        ),
+        (
+            AnomalyType.HUD_GLITCH,
+            "HUD Glitch Detected",
+            "HUD elements appeared corrupted.",
+        ),
+    ],
+)
+def test_summarize_renders_template_for_types(atype, title, observed):
+    event = sample_event(anomaly_type=atype, metrics={"value": 1.0})
+    draft = summarizer.summarize(event)
+
+    assert draft.title == title
+    assert observed in draft.body_md
+    assert "**Environment**: fps=5, buffer=5s" in draft.body_md
+    assert "- value: 1.0" in draft.body_md
+
+
+def test_summarize_handles_missing_metrics():
+    event = sample_event(metrics={})
+    draft = summarizer.summarize(event)
+    assert "## Metrics\nnone" in draft.body_md
+
+
+def test_summarize_uses_default_template_for_unknown_type(monkeypatch):
+    monkeypatch.setattr(summarizer, "TEMPLATES", {})
+    event = sample_event(anomaly_type=AnomalyType.BLANK)
+    draft = summarizer.summarize(event)
+
+    assert draft.title == "Blank Anomaly Detected"
+    assert "# Blank Anomaly Detected" in draft.body_md
+
+
+def test_summarize_persists_draft_to_db():
+    event = sample_event()
+    draft = summarizer.summarize(event)
+
+    with make_session() as session:
+        repo.save_draft(session, draft)
+        stored = session.query(models.Draft).one()
+
+        assert stored.title == draft.title
+        assert stored.body_md == draft.body_md


### PR DESCRIPTION
## Summary
- add Markdown templates for supported anomaly types
- implement rule-based summarizer that merges config context and metrics into Markdown draft
- test summarizer end-to-end and persist drafts to database
- expand summarizer tests to cover all anomaly types, missing metrics, and default template fallback

## Testing
- `poetry run black tests/unit/test_summarizer.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c391931f1c8328a5429c6ce4927797