### PR TITLE
chore(config): YAML thresholds + env wiring

### DIFF
--- a/app/capture/capture.py
+++ b/app/capture/capture.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import numpy as np
-import yaml
 
+from app.config.load import load_settings
 from .buffer import RollingBuffer
 
 try:  # pragma: no cover - optional dependency
@@ -26,13 +26,6 @@ try:  # pragma: no cover - optional dependency
     from PIL import Image
 except Exception:  # pragma: no cover - executed when Pillow unavailable
     Image = None
-
-
-def load_settings() -> Dict:
-    """Load capture settings from YAML configuration."""
-    cfg_path = Path(__file__).resolve().parent.parent / "config" / "settings.yaml"
-    with open(cfg_path, "r", encoding="utf-8") as fh:
-        return yaml.safe_load(fh)
 
 
 def grab(region: Optional[Dict[str, int]] = None) -> np.ndarray:
@@ -68,9 +61,9 @@ def save_frame(frame: np.ndarray, path: Path) -> None:
 def capture_loop() -> None:
     """Run the capture loop using configured settings."""
     settings = load_settings()
-    fps: int = int(settings.get("fps", 5))
-    buffer_seconds: int = int(settings.get("buffer_seconds", 5))
-    regions = settings.get("regions", {})
+    fps: int = int(settings.fps)
+    buffer_seconds: int = int(settings.buffer_seconds)
+    regions = settings.regions
     region = regions.get("full") if isinstance(regions, dict) else None
 
     session = datetime.utcnow().strftime("%Y%m%d_%H%M%S")

--- a/app/config/load.py
+++ b/app/config/load.py
@@ -78,10 +78,12 @@ def _apply_env_overrides(cfg: Dict[str, Any]) -> None:
         elif key == "buffer_seconds":
             cfg["buffer_seconds"] = _parse_env(env_val)
         elif parts[0] == "clip" and len(parts) > 1:
-            clip[parts[1]] = _parse_env(env_val)
+            subkey = "_".join(parts[1:])
+            clip[subkey] = _parse_env(env_val)
         elif parts[0] in {"blank", "freeze", "flicker"} and len(parts) > 1:
             det = detectors.setdefault(parts[0], {})
-            det[parts[1]] = _parse_env(env_val)
+            subkey = "_".join(parts[1:])
+            det[subkey] = _parse_env(env_val)
 
 
 def load_settings(path: Path | None = None) -> Settings:

--- a/app/config/load.py
+++ b/app/config/load.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+@dataclass
+class ClipSettings:
+    """Configure pre/post windows for saved clips."""
+
+    pre: int = 2
+    post: int = 2
+
+
+@dataclass
+class BlankConfig:
+    luma_thresh: int = 10
+    sat_thresh: int = 15
+    pct: float = 0.95
+    frames: int = 3
+
+
+@dataclass
+class FreezeConfig:
+    mad: float = 1.0
+    frames: int = 3
+
+
+@dataclass
+class FlickerConfig:
+    window: int = 8
+    ratio_thresh: float = 0.6
+
+
+@dataclass
+class DetectorConfigs:
+    blank: BlankConfig = field(default_factory=BlankConfig)
+    freeze: FreezeConfig = field(default_factory=FreezeConfig)
+    flicker: FlickerConfig = field(default_factory=FlickerConfig)
+
+
+@dataclass
+class Settings:
+    fps: int = 5
+    buffer_seconds: int = 5
+    clip: ClipSettings = field(default_factory=ClipSettings)
+    detectors: DetectorConfigs = field(default_factory=DetectorConfigs)
+    regions: Dict[str, Dict[str, int]] = field(default_factory=dict)
+
+
+_DEFAULT_PATH = Path(__file__).resolve().with_name("settings.yaml")
+
+
+def _parse_env(val: str) -> Any:
+    """Best-effort parse of environment variables into native types."""
+    if val.lower() in {"true", "false"}:
+        return val.lower() == "true"
+    try:
+        if "." in val:
+            return float(val)
+        return int(val)
+    except ValueError:
+        return val
+
+
+def _apply_env_overrides(cfg: Dict[str, Any]) -> None:
+    detectors = cfg.setdefault("detectors", {})
+    clip = cfg.setdefault("clip", {})
+    for env_key, env_val in os.environ.items():
+        key = env_key.lower()
+        parts = key.split("_")
+        if key == "fps":
+            cfg["fps"] = _parse_env(env_val)
+        elif key == "buffer_seconds":
+            cfg["buffer_seconds"] = _parse_env(env_val)
+        elif parts[0] == "clip" and len(parts) > 1:
+            clip[parts[1]] = _parse_env(env_val)
+        elif parts[0] in {"blank", "freeze", "flicker"} and len(parts) > 1:
+            det = detectors.setdefault(parts[0], {})
+            det[parts[1]] = _parse_env(env_val)
+
+
+def load_settings(path: Path | None = None) -> Settings:
+    """Load settings from YAML, applying environment overrides."""
+    path = path or _DEFAULT_PATH
+    data: Dict[str, Any]
+    if path.exists():
+        with open(path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    else:
+        data = {}
+
+    _apply_env_overrides(data)
+
+    clip_cfg = data.get("clip", {})
+    det_cfg = data.get("detectors", {})
+
+    settings = Settings(
+        fps=int(data.get("fps", 5)),
+        buffer_seconds=int(data.get("buffer_seconds", 5)),
+        clip=ClipSettings(
+            pre=int(clip_cfg.get("pre", 2)),
+            post=int(clip_cfg.get("post", 2)),
+        ),
+        detectors=DetectorConfigs(
+            blank=BlankConfig(
+                luma_thresh=int(det_cfg.get("blank", {}).get("luma_thresh", 10)),
+                sat_thresh=int(det_cfg.get("blank", {}).get("sat_thresh", 15)),
+                pct=float(det_cfg.get("blank", {}).get("pct", 0.95)),
+                frames=int(det_cfg.get("blank", {}).get("frames", 3)),
+            ),
+            freeze=FreezeConfig(
+                mad=float(det_cfg.get("freeze", {}).get("mad", 1.0)),
+                frames=int(det_cfg.get("freeze", {}).get("frames", 3)),
+            ),
+            flicker=FlickerConfig(
+                window=int(det_cfg.get("flicker", {}).get("window", 8)),
+                ratio_thresh=float(det_cfg.get("flicker", {}).get("ratio_thresh", 0.6)),
+            ),
+        ),
+        regions=data.get("regions", {}),
+    )
+
+    return settings
+
+
+__all__ = ["Settings", "load_settings"]

--- a/app/config/settings.yaml
+++ b/app/config/settings.yaml
@@ -1,8 +1,23 @@
 fps: 5
 buffer_seconds: 5
+clip:
+  pre: 2
+  post: 2
 regions:
   full:
     top: 0
     left: 0
     width: 1920
     height: 1080
+detectors:
+  blank:
+    luma_thresh: 10
+    sat_thresh: 15
+    pct: 0.95
+    frames: 3
+  freeze:
+    mad: 1.0
+    frames: 3
+  flicker:
+    window: 8
+    ratio_thresh: 0.6

--- a/app/nlp/summarizer.py
+++ b/app/nlp/summarizer.py
@@ -1,31 +1,19 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Dict
 
-import yaml
-
+from app.config.load import load_settings
 from app.schemas.models import AnomalyEvent, BugDraft
 from .templates import DEFAULT_TEMPLATE, TEMPLATES
 
-# Load simple context from config/settings.yaml
-_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "settings.yaml"
 
-
-def _load_settings(path: Path) -> Dict[str, object]:
-    if path.exists():
-        with open(path, "r", encoding="utf-8") as fh:
-            return yaml.safe_load(fh) or {}
-    return {}
-
-
-_SETTINGS = _load_settings(_CONFIG_PATH)
+_SETTINGS = load_settings()
 
 
 def _environment_context() -> str:
     """Compose a small environment string from config settings."""
-    fps = _SETTINGS.get("fps")
-    buffer_s = _SETTINGS.get("buffer_seconds")
+    fps = getattr(_SETTINGS, "fps", None)
+    buffer_s = getattr(_SETTINGS, "buffer_seconds", None)
     parts = []
     if fps is not None:
         parts.append(f"fps={fps}")

--- a/tests/unit/test_config_env.py
+++ b/tests/unit/test_config_env.py
@@ -27,3 +27,9 @@ def test_env_override_changes_freeze_frames(monkeypatch, tmp_path):
         pkt = make_packet(img, tmp_path, i)
         evt = freeze_det.process(pkt, state)
     assert evt is not None
+
+
+def test_env_override_nested_key(monkeypatch):
+    monkeypatch.setenv("BLANK_LUMA_THRESH", "20")
+    settings = load_settings()
+    assert settings.detectors.blank.luma_thresh == 20

--- a/tests/unit/test_config_env.py
+++ b/tests/unit/test_config_env.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+import cv2
+import numpy as np
+
+from app.config.load import load_settings
+from app.detectors.pipeline import DetectorPipeline
+from app.detectors.freeze import FreezeDetector
+from app.schemas.models import FramePacket
+
+
+def make_packet(img: np.ndarray, tmp_path, frame_id: int) -> FramePacket:
+    path = tmp_path / f"frame_{frame_id}.png"
+    cv2.imwrite(str(path), img)
+    return FramePacket(frame_id=frame_id, timestamp=datetime.utcnow(), path=path)
+
+
+def test_env_override_changes_freeze_frames(monkeypatch, tmp_path):
+    monkeypatch.setenv("FREEZE_FRAMES", "2")
+    settings = load_settings()
+    pipeline = DetectorPipeline.from_yaml(settings=settings)
+    freeze_det = next(d for d in pipeline.detectors if isinstance(d, FreezeDetector))
+    state = {}
+    img = np.zeros((32, 32, 3), dtype=np.uint8)
+    evt = None
+    for i in range(3):
+        pkt = make_packet(img, tmp_path, i)
+        evt = freeze_det.process(pkt, state)
+    assert evt is not None


### PR DESCRIPTION
## Summary
- expand settings with clip windows and per-detector thresholds
- centralize settings loading with typed dataclasses and env overrides
- pipeline and capture now honor loaded thresholds; added test for env override

## Testing
- `poetry run black .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3a625e4688328921b19fdaae65ac5