### PR TITLE
feat(api): add FastAPI server for events and drafts

### DIFF
--- a/app/api/server.py
+++ b/app/api/server.py
@@ -1,0 +1,70 @@
+"""FastAPI server exposing events, drafts and media for a local dashboard."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+EVENTS_DIR = BASE_DIR / "events"
+DRAFTS_DIR = BASE_DIR / "drafts"
+MEDIA_DIR = BASE_DIR / "media"
+
+app = FastAPI(title="FC25 Bug Reporter API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # allow requests from local dashboard
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def _read_json_files(directory: Path) -> list[dict]:
+    """Return JSON content from all ``*.json`` files in ``directory``.
+
+    Missing directories return an empty list.
+    """
+    items: list[dict] = []
+    if directory.exists():
+        for path in sorted(directory.glob("*.json")):
+            try:
+                items.append(json.loads(path.read_text()))
+            except Exception:
+                # skip malformed JSON files to avoid crashing the API
+                continue
+    return items
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.get("/events")
+def list_events() -> list[dict]:
+    """List stored event JSON payloads."""
+    return _read_json_files(EVENTS_DIR)
+
+
+@app.get("/drafts")
+def list_drafts() -> list[dict]:
+    """List stored bug draft JSON payloads."""
+    return _read_json_files(DRAFTS_DIR)
+
+
+@app.get("/media/{path:path}")
+def get_media(path: str):
+    """Serve media files from the local ``media`` directory."""
+    file_path = (MEDIA_DIR / path).resolve()
+    if not str(file_path).startswith(str(MEDIA_DIR.resolve())):
+        raise HTTPException(status_code=400, detail="Invalid path")
+    if not file_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(file_path)

--- a/app/dashboard/index.html
+++ b/app/dashboard/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Bug Events Dashboard</title>
+  <style>
+    body { font-family: sans-serif; display: flex; gap: 1rem; }
+    #events { width: 30%; list-style: none; padding: 0; }
+    #events li { cursor: pointer; padding: 0.25rem; border-bottom: 1px solid #ccc; }
+    #events li:hover { background: #f0f0f0; }
+    #preview { flex: 1; }
+    #preview img { max-width: 100%; display: block; margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+  <ul id="events"></ul>
+  <div id="preview">
+    <img id="shot" alt="screenshot" />
+    <div id="md"></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    async function load() {
+      const api = "http://localhost:8000";
+      const [eventsRes, draftsRes] = await Promise.all([
+        fetch(`${api}/events`),
+        fetch(`${api}/drafts`)
+      ]);
+      const events = await eventsRes.json();
+      const drafts = await draftsRes.json();
+      const list = document.getElementById('events');
+      events.forEach(evt => {
+        const li = document.createElement('li');
+        li.textContent = `#${evt.id} ${evt.type || ''}`;
+        li.addEventListener('click', () => {
+          document.getElementById('shot').src = `${api}/media/events/${evt.id}/screenshot.png`;
+          const draft = drafts.find(d => d.event_id === evt.id);
+          document.getElementById('md').innerHTML = draft ? marked.parse(draft.body_md) : '';
+        });
+        list.appendChild(li);
+      });
+    }
+    load();
+  </script>
+</body>
+</html>

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ version = "4.10.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1"},
     {file = "anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6"},
@@ -76,6 +76,18 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.10)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "certifi"
+version = "2025.8.3"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
+    {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
+]
 
 [[package]]
 name = "click"
@@ -269,11 +281,59 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.27.2"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
@@ -281,7 +341,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -1483,7 +1543,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -1788,4 +1848,4 @@ ml = ["torch"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "62abfd85d1b8a40127f5632d8686a88e35d202f1bf7dd60368d7655343bbe681"
+content-hash = "443797c6963c2a03924af5d85900ae5112d9e7d687110a1c87150c05948d3ed8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,5 @@ black = "^25.1.0"
 isort = "^6.0.1"
 mypy = "^1.17.1"
 pytest-asyncio = "^1.1.0"
+httpx = "^0.27.0"
 

--- a/tests/unit/test_api_server.py
+++ b/tests/unit/test_api_server.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.api import server
+
+
+def make_sample_dirs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    events = tmp_path / "events"
+    drafts = tmp_path / "drafts"
+    media = tmp_path / "media"
+    events.mkdir()
+    drafts.mkdir()
+    media.mkdir()
+    return events, drafts, media
+
+
+def test_health_endpoint():
+    client = TestClient(server.app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_events_drafts_and_media(tmp_path, monkeypatch):
+    events_dir, drafts_dir, media_dir = make_sample_dirs(tmp_path)
+    (events_dir / "1.json").write_text('{"id": 1, "type": "blank"}')
+    (drafts_dir / "1.json").write_text('{"event_id": 1, "body_md": "# Title"}')
+    sample = media_dir / "events" / "1"
+    sample.mkdir(parents=True)
+    (sample / "screenshot.png").write_bytes(b"img")
+
+    monkeypatch.setattr(server, "EVENTS_DIR", events_dir)
+    monkeypatch.setattr(server, "DRAFTS_DIR", drafts_dir)
+    monkeypatch.setattr(server, "MEDIA_DIR", media_dir)
+
+    client = TestClient(server.app)
+    assert client.get("/events").json() == [{"id": 1, "type": "blank"}]
+    assert client.get("/drafts").json() == [{"event_id": 1, "body_md": "# Title"}]
+    res = client.get("/media/events/1/screenshot.png")
+    assert res.status_code == 200
+    assert res.content == b"img"
+
+
+def test_media_invalid_path(tmp_path, monkeypatch):
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+    monkeypatch.setattr(server, "MEDIA_DIR", media_dir)
+    from fastapi import HTTPException
+
+    try:
+        server.get_media("../secret.txt")
+        assert False, "Expected HTTPException for path traversal"
+    except HTTPException as exc:
+        assert exc.status_code == 400


### PR DESCRIPTION
## Summary
- add FastAPI server exposing health, events, drafts and media endpoints
- enable permissive CORS for local dashboard
- add minimal dashboard that lists events and shows screenshot and markdown preview
- include httpx dev dependency and API server tests

## Testing
- `poetry run black .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3a5ea96cc8328865738d6ac134532